### PR TITLE
Use a union type instead of ctor overloading

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -144,7 +144,10 @@ document.getElementById('changeConfigBtn').onclick() = function() {
 
 ```
 partial interface PresentationRequest {
-  constructor(sequence<PresentationSource> sources);
+  // This constructor replaces
+  //   constructor(sequence<USVString> urls);
+  // in the current Presentation API spec.
+  constructor(sequence<(USVString or PresentationSource)> sources);
 }
 
 partial interface PresentationConnection {


### PR DESCRIPTION
If I understand the [WebIDL spec](https://webidl.spec.whatwg.org/#idl-overloading) correctly, we cannot overload `constructor(sequence<USVString>)` with `constructor(sequence<PresentationSource>)`, because sequences are indistinguishable from one another. So this PR changes it to use a union type `(USVString or PresentationSource)` instead.